### PR TITLE
[BC-Breaking] TuSimple max lane number testing constrain bug fix

### DIFF
--- a/configs.yaml
+++ b/configs.yaml
@@ -104,6 +104,7 @@ TUSIMPLE:  # TuSimple
     BASE_DIR: '../../dataset/tusimple'
     # training size/original size
     SIZES: [ !!python/tuple [360, 640], !!python/tuple [720, 1280] ]
+    MAX_LANE: 5
     NUM_CLASSES: 7
     COLORS: [ [ 0, 0, 0 ],
               [255, 0, 255], [ 0, 255, 0], [0, 0, 255], [255, 0, 0], [255, 255, 0], [0, 255, 255],
@@ -117,6 +118,7 @@ CULANE:  # CULane
     BASE_DIR: '../../dataset/culane'
     # training size/original size
     SIZES: [ !!python/tuple [288, 800], !!python/tuple [590, 1640] ]
+    MAX_LANE: 4
     NUM_CLASSES: 5
     # https://github.com/XingangPan/SCNN/blob/master/tools/prob2lines/main.m
     COLORS: [ [ 0, 0, 0 ],

--- a/docs/MODEL_ZOO.md
+++ b/docs/MODEL_ZOO.md
@@ -41,19 +41,19 @@
 
 | method | backbone | accuracy | FP | FN | |
 | :---: | :---: | :---: | :---: | :---: | :---: |
-| Baseline | VGG16 | 93.57% | 0.0992 | 0.1058 | [model](https://drive.google.com/file/d/1ChK0hApqLU0xUiEm4Wul-gNYQDQka151/view?usp=sharing) \| [shell](../tools/shells/vgg16_baseline_tusimple.sh) |
-| Baseline | ResNet18 | 93.98% | 0.0874 | 0.0921 | [model](https://drive.google.com/file/d/17VKnwsN4WMbpnD4DgaaerppjXybqn-LG/view?usp=sharing) \| [shell](../tools/shells/resnet18_baseline_tusimple.sh) |
-| Baseline | ResNet34 | 94.99% | 0.0615 | 0.0638 | [model](https://drive.google.com/file/d/1ch5YCNAQPhkPR2PRBNn07kE_t8kicLpq/view?usp=sharing) \| [shell](../tools/shells/resnet34_baseline_tusimple.sh) |
-| Baseline | ResNet50 | 94.71% | 0.0644 | 0.0695 | [model](https://drive.google.com/file/d/10KBMVGc63kPvqL_2deaLfTfC3fSAtnju/view?usp=sharing) \| [shell](../tools/shells/resnet50_baseline_tusimple.sh) |
-| Baseline | ResNet101 | 94.83% | 0.0612 | 0.0677 | [model](https://drive.google.com/file/d/1sFJna_oJ6dfd9AMiAEbragpLSvpduGff/view?usp=sharing) \| [shell](../tools/shells/resnet101_baseline_tusimple.sh) |
-| Baseline | ERFNet | 95.24% | 0.0569 | 0.0457 | [model](https://drive.google.com/file/d/12n_ck3Ir86j3VOhIn0hT96Ru4n8nhP5G/view?usp=sharing) \| [shell](../tools/shells/erfnet_baseline_tusimple.sh) |
-| Baseline | ENet | 95.58% | 0.0653 | 0.0507 | [model](https://drive.google.com/file/d/1CNSox62ghs0ArDVJb9mTZ1NVvqSkUNYC/view?usp=sharing) \| [shell](../tools/shells/enet_baseline_tusimple.sh) |
-| SCNN | VGG16 | 94.65% | 0.0627 | 0.0675 | [model](https://drive.google.com/file/d/1Fd46-f_8q-fGcJEI_PhPyh7aBY1uqbIw/view?usp=sharing) \| [shell](../tools/shells/vgg16_scnn_tusimple.sh) |
-| SCNN | ResNet18 | 94.30% | 0.0736 | 0.0799 | [model](https://drive.google.com/file/d/1cmP73GKD_9R9ka0sJdY8V0z04bE5jkaZ/view?usp=sharing) \| [shell](../tools/shells/resnet18_scnn_tusimple.sh) |
-| SCNN | ResNet34 | 94.76% | 0.0671 | 0.0694 | [model](https://drive.google.com/file/d/1LHlnPsIsr4RCJar4UKBVfikS41P9e3Em/view?usp=sharing) \| [shell](../tools/shells/resnet34_scnn_tusimple.sh) |
-| SCNN | ResNet50 | 95.01% | 0.0550 | 0.0611 | [model](https://drive.google.com/file/d/1YK-PzdE9q8zn48isiBxwaZEdRsFw_oHe/view?usp=sharing) \| [shell](../tools/shells/resnet50_scnn_tusimple.sh) |
-| SCNN | ResNet101 | 95.21% | 0.0511 | 0.0552 | [model](https://drive.google.com/file/d/13qk5rIHqhDlwylZP9S-8fN53DexPTBQy/view?usp=sharing) \| [shell](../tools/shells/resnet101_scnn_tusimple.sh) |
-| SCNN | ERFNet | 96.12% | 0.0468 | 0.0335 | [model](https://drive.google.com/file/d/1rzE2fZ5mQswMIm6ICK1lWH-rsQyjRbxL/view?usp=sharing) \| [shell](../tools/shells/erfnet_scnn_tusimple.sh) |
+| Baseline | VGG16 | 93.94% | 0.0998 | 0.1021 | [model](https://drive.google.com/file/d/1ChK0hApqLU0xUiEm4Wul-gNYQDQka151/view?usp=sharing) \| [shell](../tools/shells/vgg16_baseline_tusimple.sh) |
+| Baseline | ResNet18 | 94.25% | 0.0881 | 0.0894 | [model](https://drive.google.com/file/d/17VKnwsN4WMbpnD4DgaaerppjXybqn-LG/view?usp=sharing) \| [shell](../tools/shells/resnet18_baseline_tusimple.sh) |
+| Baseline | ResNet34 | 95.29% | 0.0621 | 0.0608 | [model](https://drive.google.com/file/d/1ch5YCNAQPhkPR2PRBNn07kE_t8kicLpq/view?usp=sharing) \| [shell](../tools/shells/resnet34_baseline_tusimple.sh) |
+| Baseline | ResNet50 | 95.12% | 0.0649 | 0.0653 | [model](https://drive.google.com/file/d/10KBMVGc63kPvqL_2deaLfTfC3fSAtnju/view?usp=sharing) \| [shell](../tools/shells/resnet50_baseline_tusimple.sh) |
+| Baseline | ResNet101 | 95.14% | 0.0617 | 0.0646 | [model](https://drive.google.com/file/d/1sFJna_oJ6dfd9AMiAEbragpLSvpduGff/view?usp=sharing) \| [shell](../tools/shells/resnet101_baseline_tusimple.sh) |
+| Baseline | ERFNet | 96.00% | 0.0582 | 0.0380 | [model](https://drive.google.com/file/d/12n_ck3Ir86j3VOhIn0hT96Ru4n8nhP5G/view?usp=sharing) \| [shell](../tools/shells/erfnet_baseline_tusimple.sh) |
+| Baseline | ENet | 95.61% | 0.0655 | 0.0503 | [model](https://drive.google.com/file/d/1CNSox62ghs0ArDVJb9mTZ1NVvqSkUNYC/view?usp=sharing) \| [shell](../tools/shells/enet_baseline_tusimple.sh) |
+| SCNN | VGG16 | 95.17% | 0.0637 | 0.0622 | [model](https://drive.google.com/file/d/1Fd46-f_8q-fGcJEI_PhPyh7aBY1uqbIw/view?usp=sharing) \| [shell](../tools/shells/vgg16_scnn_tusimple.sh) |
+| SCNN | ResNet18 | 94.71% | 0.0743 | 0.0757 | [model](https://drive.google.com/file/d/1cmP73GKD_9R9ka0sJdY8V0z04bE5jkaZ/view?usp=sharing) \| [shell](../tools/shells/resnet18_scnn_tusimple.sh) |
+| SCNN | ResNet34 | 95.24% | 0.0682 | 0.0645 | [model](https://drive.google.com/file/d/1LHlnPsIsr4RCJar4UKBVfikS41P9e3Em/view?usp=sharing) \| [shell](../tools/shells/resnet34_scnn_tusimple.sh) |
+| SCNN | ResNet50 | 95.56% | 0.0561 | 0.0556 | [model](https://drive.google.com/file/d/1YK-PzdE9q8zn48isiBxwaZEdRsFw_oHe/view?usp=sharing) \| [shell](../tools/shells/resnet50_scnn_tusimple.sh) |
+| SCNN | ResNet101 | 95.69% | 0.0519 | 0.0504 | [model](https://drive.google.com/file/d/13qk5rIHqhDlwylZP9S-8fN53DexPTBQy/view?usp=sharing) \| [shell](../tools/shells/resnet101_scnn_tusimple.sh) |
+| SCNN | ERFNet | 96.29% | 0.0470 | 0.0318 | [model](https://drive.google.com/file/d/1rzE2fZ5mQswMIm6ICK1lWH-rsQyjRbxL/view?usp=sharing) \| [shell](../tools/shells/erfnet_scnn_tusimple.sh) |
 
 ### CULane detailed performance (best):
 

--- a/docs/MODEL_ZOO.md
+++ b/docs/MODEL_ZOO.md
@@ -4,14 +4,14 @@
 
 | method | backbone | resolution | mixed precision? | dataset | metric | average | best | training time <br> *(2080 Ti)* |
 | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
-| Baseline | VGG16 | 360 x 640 | *yes* | Tusimple | Accuracy | 93.39% | 93.57% | 1.5h |
+| Baseline | VGG16 | 360 x 640 | *yes* | TuSimple | Accuracy | 93.39% | 93.57% | 1.5h |
 | Baseline | ResNet18 | 360 x 640 | *yes* | TuSimple | Accuracy | 93.80% | 93.98% | 0.7h |
 | Baseline | ResNet34 | 360 x 640 | *yes* | TuSimple | Accuracy | 94.94% | 94.99% | 1.1h |
 | Baseline | ResNet50 | 360 x 640 | *yes* | TuSimple | Accuracy | 94.67% | 94.71% | 1.5h |
 | Baseline | ResNet101 | 360 x 640 | *yes* | TuSimple | Accuracy | 94.77% | 94.83% | 2.6h |
 | Baseline | ERFNet | 360 x 640 | *yes* | TuSimple | Accuracy | 95.15% | 95.24% | 0.8h |
 | Baseline | ENet<sup>#</sup> | 360 x 640 | *yes* | TuSimple | Accuracy | 95.38% | 95.58% | 1h<sup>+</sup> |
-| SCNN | VGG16 | 360 x 640 | *yes* | Tusimple | Accuracy | 94.46% | 94.65% | 2h |
+| SCNN | VGG16 | 360 x 640 | *yes* | TuSimple | Accuracy | 94.46% | 94.65% | 2h |
 | SCNN | ResNet18 | 360 x 640 | *yes* | TuSimple | Accuracy | 94.21% | 94.30% | 1.2h |
 | SCNN | ResNet34 | 360 x 640 | *yes* | TuSimple | Accuracy | 94.66% | 94.76% | 1.6h |
 | SCNN | ResNet50 | 360 x 640 | *yes* | TuSimple | Accuracy | 94.93% | 95.01% | 2.4h |

--- a/docs/MODEL_ZOO.md
+++ b/docs/MODEL_ZOO.md
@@ -37,7 +37,7 @@
 
 *<sup>#</sup> No pre-training.*
 
-### Tusimple detailed performance (best):
+### TuSimple detailed performance (best):
 
 | method | backbone | accuracy | FP | FN | |
 | :---: | :---: | :---: | :---: | :---: | :---: |

--- a/docs/MODEL_ZOO.md
+++ b/docs/MODEL_ZOO.md
@@ -4,14 +4,14 @@
 
 | method | backbone | resolution | mixed precision? | dataset | metric | average | best | training time <br> *(2080 Ti)* |
 | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
-| Baseline | VGG16 | 360 x 640 | *yes* | TuSimple | Accuracy | 93.39% | 93.57% | 1.5h |
+| Baseline | VGG16 | 360 x 640 | *yes* | TuSimple | Accuracy | 93.79% | 93.94% | 1.5h |
 | Baseline | ResNet18 | 360 x 640 | *yes* | TuSimple | Accuracy | 94.18% | 94.25% | 0.7h |
 | Baseline | ResNet34 | 360 x 640 | *yes* | TuSimple | Accuracy | 95.23% | 95.31% | 1.1h |
 | Baseline | ResNet50 | 360 x 640 | *yes* | TuSimple | Accuracy | 95.07% | 95.12% | 1.5h |
 | Baseline | ResNet101 | 360 x 640 | *yes* | TuSimple | Accuracy | 95.15% | 95.19% | 2.6h |
 | Baseline | ERFNet | 360 x 640 | *yes* | TuSimple | Accuracy | 96.02% | 96.04% | 0.8h |
-| Baseline | ENet<sup>#</sup> | 360 x 640 | *yes* | TuSimple | Accuracy | 95.38% | 95.58% | 1h<sup>+</sup> |
-| SCNN | VGG16 | 360 x 640 | *yes* | TuSimple | Accuracy | 94.46% | 94.65% | 2h |
+| Baseline | ENet<sup>#</sup> | 360 x 640 | *yes* | TuSimple | Accuracy | 95.55% | 95.61% | 1h<sup>+</sup> |
+| SCNN | VGG16 | 360 x 640 | *yes* | TuSimple | Accuracy | 95.01% | 95.17% | 2h |
 | SCNN | ResNet18 | 360 x 640 | *yes* | TuSimple | Accuracy | 94.69% | 94.77% | 1.2h |
 | SCNN | ResNet34 | 360 x 640 | *yes* | TuSimple | Accuracy | 95.19% | 95.25% | 1.6h |
 | SCNN | ResNet50 | 360 x 640 | *yes* | TuSimple | Accuracy | 95.43% | 95.56% | 2.4h |

--- a/docs/MODEL_ZOO.md
+++ b/docs/MODEL_ZOO.md
@@ -5,18 +5,18 @@
 | method | backbone | resolution | mixed precision? | dataset | metric | average | best | training time <br> *(2080 Ti)* |
 | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
 | Baseline | VGG16 | 360 x 640 | *yes* | TuSimple | Accuracy | 93.39% | 93.57% | 1.5h |
-| Baseline | ResNet18 | 360 x 640 | *yes* | TuSimple | Accuracy | 93.80% | 93.98% | 0.7h |
-| Baseline | ResNet34 | 360 x 640 | *yes* | TuSimple | Accuracy | 94.94% | 94.99% | 1.1h |
-| Baseline | ResNet50 | 360 x 640 | *yes* | TuSimple | Accuracy | 94.67% | 94.71% | 1.5h |
-| Baseline | ResNet101 | 360 x 640 | *yes* | TuSimple | Accuracy | 94.77% | 94.83% | 2.6h |
-| Baseline | ERFNet | 360 x 640 | *yes* | TuSimple | Accuracy | 95.15% | 95.24% | 0.8h |
+| Baseline | ResNet18 | 360 x 640 | *yes* | TuSimple | Accuracy | 94.18% | 94.25% | 0.7h |
+| Baseline | ResNet34 | 360 x 640 | *yes* | TuSimple | Accuracy | 95.23% | 95.31% | 1.1h |
+| Baseline | ResNet50 | 360 x 640 | *yes* | TuSimple | Accuracy | 95.07% | 95.12% | 1.5h |
+| Baseline | ResNet101 | 360 x 640 | *yes* | TuSimple | Accuracy | 95.15% | 95.19% | 2.6h |
+| Baseline | ERFNet | 360 x 640 | *yes* | TuSimple | Accuracy | 96.02% | 96.04% | 0.8h |
 | Baseline | ENet<sup>#</sup> | 360 x 640 | *yes* | TuSimple | Accuracy | 95.38% | 95.58% | 1h<sup>+</sup> |
 | SCNN | VGG16 | 360 x 640 | *yes* | TuSimple | Accuracy | 94.46% | 94.65% | 2h |
-| SCNN | ResNet18 | 360 x 640 | *yes* | TuSimple | Accuracy | 94.21% | 94.30% | 1.2h |
-| SCNN | ResNet34 | 360 x 640 | *yes* | TuSimple | Accuracy | 94.66% | 94.76% | 1.6h |
-| SCNN | ResNet50 | 360 x 640 | *yes* | TuSimple | Accuracy | 94.93% | 95.01% | 2.4h |
-| SCNN | ResNet101 | 360 x 640 | *yes* | TuSimple | Accuracy | 95.09% | 95.21% | 3.5h |
-| SCNN | ERFNet | 360 x 640 | *yes* | TuSimple | Accuracy | 96.00% | 96.12% | 1.6h |
+| SCNN | ResNet18 | 360 x 640 | *yes* | TuSimple | Accuracy | 94.69% | 94.77% | 1.2h |
+| SCNN | ResNet34 | 360 x 640 | *yes* | TuSimple | Accuracy | 95.19% | 95.25% | 1.6h |
+| SCNN | ResNet50 | 360 x 640 | *yes* | TuSimple | Accuracy | 95.43% | 95.56% | 2.4h |
+| SCNN | ResNet101 | 360 x 640 | *yes* | TuSimple | Accuracy | 95.56% | 95.69% | 3.5h |
+| SCNN | ERFNet | 360 x 640 | *yes* | TuSimple | Accuracy | 96.18% | 96.29% | 1.6h |
 | Baseline | VGG16 | 288 x 800 | *yes* | CULane | F measure | 65.93 | 66.09 | 9.3h |
 | Baseline | ResNet18 | 288 x 800 | *yes* | CULane | F measure | 65.19 | 65.30 | 5.3h |
 | Baseline | ResNet34 | 288 x 800 | *yes* | CULane | F measure | 69.82 | 69.92 | 7.3h |
@@ -43,14 +43,14 @@
 | :---: | :---: | :---: | :---: | :---: | :---: |
 | Baseline | VGG16 | 93.94% | 0.0998 | 0.1021 | [model](https://drive.google.com/file/d/1ChK0hApqLU0xUiEm4Wul-gNYQDQka151/view?usp=sharing) \| [shell](../tools/shells/vgg16_baseline_tusimple.sh) |
 | Baseline | ResNet18 | 94.25% | 0.0881 | 0.0894 | [model](https://drive.google.com/file/d/17VKnwsN4WMbpnD4DgaaerppjXybqn-LG/view?usp=sharing) \| [shell](../tools/shells/resnet18_baseline_tusimple.sh) |
-| Baseline | ResNet34 | 95.29% | 0.0621 | 0.0608 | [model](https://drive.google.com/file/d/1ch5YCNAQPhkPR2PRBNn07kE_t8kicLpq/view?usp=sharing) \| [shell](../tools/shells/resnet34_baseline_tusimple.sh) |
+| Baseline | ResNet34 | 95.31% | 0.0640 | 0.0622 | [model](https://drive.google.com/file/d/1NAck0aQZK_wAHer4xB8xzegxDWk9EFtG/view?usp=sharing) \| [shell](../tools/shells/resnet34_baseline_tusimple.sh) |
 | Baseline | ResNet50 | 95.12% | 0.0649 | 0.0653 | [model](https://drive.google.com/file/d/10KBMVGc63kPvqL_2deaLfTfC3fSAtnju/view?usp=sharing) \| [shell](../tools/shells/resnet50_baseline_tusimple.sh) |
-| Baseline | ResNet101 | 95.14% | 0.0617 | 0.0646 | [model](https://drive.google.com/file/d/1sFJna_oJ6dfd9AMiAEbragpLSvpduGff/view?usp=sharing) \| [shell](../tools/shells/resnet101_baseline_tusimple.sh) |
-| Baseline | ERFNet | 96.00% | 0.0582 | 0.0380 | [model](https://drive.google.com/file/d/12n_ck3Ir86j3VOhIn0hT96Ru4n8nhP5G/view?usp=sharing) \| [shell](../tools/shells/erfnet_baseline_tusimple.sh) |
+| Baseline | ResNet101 | 95.19% | 0.0619 | 0.0620 | [model](https://drive.google.com/file/d/1mELtKB3e8ntOmPovhnMphXWKf_bv83ef/view?usp=sharing) \| [shell](../tools/shells/resnet101_baseline_tusimple.sh) |
+| Baseline | ERFNet | 96.04% | 0.0591 | 0.0365 | [model](https://drive.google.com/file/d/1rLWDP_dkIQ7sBsCEzJi8T7ET1EPghhJJ/view?usp=sharing) \| [shell](../tools/shells/erfnet_baseline_tusimple.sh) |
 | Baseline | ENet | 95.61% | 0.0655 | 0.0503 | [model](https://drive.google.com/file/d/1CNSox62ghs0ArDVJb9mTZ1NVvqSkUNYC/view?usp=sharing) \| [shell](../tools/shells/enet_baseline_tusimple.sh) |
 | SCNN | VGG16 | 95.17% | 0.0637 | 0.0622 | [model](https://drive.google.com/file/d/1Fd46-f_8q-fGcJEI_PhPyh7aBY1uqbIw/view?usp=sharing) \| [shell](../tools/shells/vgg16_scnn_tusimple.sh) |
-| SCNN | ResNet18 | 94.71% | 0.0743 | 0.0757 | [model](https://drive.google.com/file/d/1cmP73GKD_9R9ka0sJdY8V0z04bE5jkaZ/view?usp=sharing) \| [shell](../tools/shells/resnet18_scnn_tusimple.sh) |
-| SCNN | ResNet34 | 95.24% | 0.0682 | 0.0645 | [model](https://drive.google.com/file/d/1LHlnPsIsr4RCJar4UKBVfikS41P9e3Em/view?usp=sharing) \| [shell](../tools/shells/resnet34_scnn_tusimple.sh) |
+| SCNN | ResNet18 | 94.77% | 0.0753 | 0.0737 | [model](https://drive.google.com/file/d/1cHp9gG2NgtC1iSp2LZMPF_UKiCb-fVkn/view?usp=sharing) \| [shell](../tools/shells/resnet18_scnn_tusimple.sh) |
+| SCNN | ResNet34 | 95.25% | 0.0627 | 0.0634 | [model](https://drive.google.com/file/d/1M0ROpEHV8DGJT4xWq2eURcbqMzpea1q7/view?usp=sharing) \| [shell](../tools/shells/resnet34_scnn_tusimple.sh) |
 | SCNN | ResNet50 | 95.56% | 0.0561 | 0.0556 | [model](https://drive.google.com/file/d/1YK-PzdE9q8zn48isiBxwaZEdRsFw_oHe/view?usp=sharing) \| [shell](../tools/shells/resnet50_scnn_tusimple.sh) |
 | SCNN | ResNet101 | 95.69% | 0.0519 | 0.0504 | [model](https://drive.google.com/file/d/13qk5rIHqhDlwylZP9S-8fN53DexPTBQy/view?usp=sharing) \| [shell](../tools/shells/resnet101_scnn_tusimple.sh) |
 | SCNN | ERFNet | 96.29% | 0.0470 | 0.0318 | [model](https://drive.google.com/file/d/1rzE2fZ5mQswMIm6ICK1lWH-rsQyjRbxL/view?usp=sharing) \| [shell](../tools/shells/erfnet_scnn_tusimple.sh) |

--- a/main_landec.py
+++ b/main_landec.py
@@ -61,6 +61,7 @@ if __name__ == '__main__':
     thresh = configs[configs['LANE_DATASETS'][args.dataset]]['THRESHOLD']
     weights = configs[configs['LANE_DATASETS'][args.dataset]]['WEIGHTS']
     base = configs[configs['LANE_DATASETS'][args.dataset]]['BASE_DIR']
+    max_lane = configs[configs['LANE_DATASETS'][args.dataset]]['MAX_LANE']
     device = torch.device('cpu')
     if torch.cuda.is_available():
         device = torch.device('cuda:0')
@@ -97,7 +98,8 @@ if __name__ == '__main__':
 
         else:  # Test with official scripts later (so just predict lanes here)
             test_one_set(net=net, device=device, loader=data_loader, is_mixed_precision=args.mixed_precision, gap=gap,
-                         input_sizes=input_sizes, ppl=ppl, thresh=thresh, dataset=args.dataset, method=args.method)
+                         input_sizes=input_sizes, ppl=ppl, thresh=thresh, dataset=args.dataset, method=args.method,
+                         max_lane=max_lane)
     else:
         if args.method == 'scnn' or args.method == 'baseline':
             criterion = LaneLoss(weight=weights, ignore_index=255)

--- a/tools/shells/erfnet_baseline_tusimple.sh
+++ b/tools/shells/erfnet_baseline_tusimple.sh
@@ -1,4 +1,4 @@
-# Trained weights: erfnet_baseline_tusimple_20210201.pt
+# Trained weights: erfnet_baseline_tusimple_20210424.pt
 # Training
 python main_landec.py --epochs=50 --lr=0.2 --batch-size=20 --dataset=tusimple --method=baseline --backbone=erfnet --mixed-precision --exp-name=erfnet_baseline_tusimple
 # Predicting lane points for testing

--- a/tools/shells/resnet101_baseline_tusimple.sh
+++ b/tools/shells/resnet101_baseline_tusimple.sh
@@ -1,4 +1,4 @@
-# Trained weights: resnet101_baseline_tusimple_20210217.pt
+# Trained weights: resnet101_baseline_tusimple_20210424.pt
 # Training, scale lr by square root on 11G GPU
 python main_landec.py --epochs=50 --lr=0.13 --batch-size=8 --dataset=tusimple --method=baseline --backbone=resnet101 --workers=4 --warmup-steps=500 --mixed-precision --exp-name=resnet101_baseline_tusimple
 # Predicting lane points for testing

--- a/tools/shells/resnet18_scnn_tusimple.sh
+++ b/tools/shells/resnet18_scnn_tusimple.sh
@@ -1,4 +1,4 @@
-# Trained weights: resnet18_scnn_tusimple_20210216.pt
+# Trained weights: resnet18_scnn_tusimple_20210424.pt
 # Training
 python main_landec.py --epochs=50 --lr=0.2 --batch-size=20 --dataset=tusimple --method=scnn --backbone=resnet18 --mixed-precision --exp-name=resnet18_scnn_tusimple
 # Predicting lane points for testing

--- a/tools/shells/resnet34_baseline_tusimple.sh
+++ b/tools/shells/resnet34_baseline_tusimple.sh
@@ -1,4 +1,4 @@
-# Trained weights: resnet34_baseline_tusimple_20210216.pt
+# Trained weights: resnet34_baseline_tusimple_20210424.pt
 # Training
 python main_landec.py --epochs=50 --lr=0.2 --batch-size=20 --dataset=tusimple --method=baseline --backbone=resnet34 --mixed-precision --exp-name=resnet34_baseline_tusimple
 # Predicting lane points for testing

--- a/tools/shells/resnet34_scnn_tusimple.sh
+++ b/tools/shells/resnet34_scnn_tusimple.sh
@@ -1,4 +1,4 @@
-# Trained weights: resnet34_scnn_tusimple_20210216.pt
+# Trained weights: resnet34_scnn_tusimple_20210424.pt
 # Training
 python main_landec.py --epochs=50 --lr=0.2 --batch-size=20 --dataset=tusimple --method=scnn --backbone=resnet34 --mixed-precision --exp-name=resnet34_scnn_tusimple
 # Predicting lane points for testing


### PR DESCRIPTION
This bug fix brings 0.1~0.4% F1 score increase on all uploaded models (on one extreme case ERFNet Baseline, 0.8%).
The original code did not mask out the lane prediction with lowest existence probability, but it accidentally masked out the first lane when the network predicted 6 lanes (TuSimple has a maximal number of 5 lanes).

This change is only applied to testing scripts, so any previous downloaded/trained weights still can be used, they just need re-testing. Also this change is too small to have much of a effect on hyper-parameter validation, so hyper-parameters will remain unchanged as well.

However, we are providing new best model weights for download (since the previous ones now are not the best among the 3 runs after re-testing), these models are:

```
erfnet_baseline_tusimple_20210201.pt
resnet101_baseline_tusimple_20210217.pt
resnet34_baseline_tusimple_20210216.pt
resnet18_scnn_tusimple_20210216.pt
resnet34_scnn_tusimple_20210216.pt
```

Be sure to re-download the new best models (filename ends with `_20210424.pt`).
