### PR TITLE
Fix import issues on some machines

### DIFF
--- a/configs/lane_detection/baseline/enet_culane.py
+++ b/configs/lane_detection/baseline/enet_culane.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.culane_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
-from configs.lane_detection.common.datasets.test_288 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.culane_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
+    from configs.lane_detection.common.datasets.test_288 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.sgd05 import optimizer
-from configs.lane_detection.common.optims.ep12_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.sgd05 import optimizer
+    from configs.lane_detection.common.optims.ep12_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/baseline/enet_tusimple.py
+++ b/configs/lane_detection/baseline/enet_tusimple.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.tusimple_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.tusimple_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_7class import loss
-from configs.lane_detection.common.optims.sgd04 import optimizer
-from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_7class import loss
+    from configs.lane_detection.common.optims.sgd04 import optimizer
+    from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/baseline/erfnet_culane.py
+++ b/configs/lane_detection/baseline/erfnet_culane.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.culane_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
-from configs.lane_detection.common.datasets.test_288 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.culane_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
+    from configs.lane_detection.common.datasets.test_288 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.sgd02 import optimizer
-from configs.lane_detection.common.optims.ep12_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.sgd02 import optimizer
+    from configs.lane_detection.common.optims.ep12_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/baseline/erfnet_llamas.py
+++ b/configs/lane_detection/baseline/erfnet_llamas.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.llamas_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.llamas_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.sgd05 import optimizer
-from configs.lane_detection.common.optims.ep10_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.sgd05 import optimizer
+    from configs.lane_detection.common.optims.ep10_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/baseline/erfnet_tusimple.py
+++ b/configs/lane_detection/baseline/erfnet_tusimple.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.tusimple_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.tusimple_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_7class import loss
-from configs.lane_detection.common.optims.sgd02 import optimizer
-from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_7class import loss
+    from configs.lane_detection.common.optims.sgd02 import optimizer
+    from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/baseline/erfnet_tusimple_aug.py
+++ b/configs/lane_detection/baseline/erfnet_tusimple_aug.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.tusimple_seg import dataset
-from configs.lane_detection.common.datasets.train_level1a_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.tusimple_seg import dataset
+    from configs.lane_detection.common.datasets.train_level1a_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_7class import loss
-from configs.lane_detection.common.optims.sgd02 import optimizer
-from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_7class import loss
+    from configs.lane_detection.common.optims.sgd02 import optimizer
+    from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/baseline/mobilenetv2_culane.py
+++ b/configs/lane_detection/baseline/mobilenetv2_culane.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.culane_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
-from configs.lane_detection.common.datasets.test_288 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.culane_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
+    from configs.lane_detection.common.datasets.test_288 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.sgd009 import optimizer
-from configs.lane_detection.common.optims.ep12_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.sgd009 import optimizer
+    from configs.lane_detection.common.optims.ep12_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/baseline/mobilenetv2_tusimple.py
+++ b/configs/lane_detection/baseline/mobilenetv2_tusimple.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.tusimple_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.tusimple_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_7class import loss
-from configs.lane_detection.common.optims.sgd009 import optimizer
-from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_7class import loss
+    from configs.lane_detection.common.optims.sgd009 import optimizer
+    from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/baseline/mobilenetv3_large_culane.py
+++ b/configs/lane_detection/baseline/mobilenetv3_large_culane.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.culane_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
-from configs.lane_detection.common.datasets.test_288 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.culane_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
+    from configs.lane_detection.common.datasets.test_288 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.sgd009 import optimizer
-from configs.lane_detection.common.optims.ep12_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.sgd009 import optimizer
+    from configs.lane_detection.common.optims.ep12_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/baseline/mobilenetv3_large_tusimple.py
+++ b/configs/lane_detection/baseline/mobilenetv3_large_tusimple.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.tusimple_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.tusimple_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_7class import loss
-from configs.lane_detection.common.optims.sgd009 import optimizer
-from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_7class import loss
+    from configs.lane_detection.common.optims.sgd009 import optimizer
+    from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/baseline/repvgg_a0_culane.py
+++ b/configs/lane_detection/baseline/repvgg_a0_culane.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.culane_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
-from configs.lane_detection.common.datasets.test_288 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.culane_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
+    from configs.lane_detection.common.datasets.test_288 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.sgd02 import optimizer
-from configs.lane_detection.common.optims.ep12_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.sgd02 import optimizer
+    from configs.lane_detection.common.optims.ep12_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/baseline/repvgg_a1_culane.py
+++ b/configs/lane_detection/baseline/repvgg_a1_culane.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.culane_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
-from configs.lane_detection.common.datasets.test_288 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.culane_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
+    from configs.lane_detection.common.datasets.test_288 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.sgd02 import optimizer
-from configs.lane_detection.common.optims.ep12_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.sgd02 import optimizer
+    from configs.lane_detection.common.optims.ep12_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/baseline/repvgg_b0_culane.py
+++ b/configs/lane_detection/baseline/repvgg_b0_culane.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.culane_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
-from configs.lane_detection.common.datasets.test_288 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.culane_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
+    from configs.lane_detection.common.datasets.test_288 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.sgd02 import optimizer
-from configs.lane_detection.common.optims.ep12_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.sgd02 import optimizer
+    from configs.lane_detection.common.optims.ep12_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/baseline/repvgg_b1g2_culane.py
+++ b/configs/lane_detection/baseline/repvgg_b1g2_culane.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.culane_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
-from configs.lane_detection.common.datasets.test_288 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.culane_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
+    from configs.lane_detection.common.datasets.test_288 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.sgd02 import optimizer
-from configs.lane_detection.common.optims.ep12_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.sgd02 import optimizer
+    from configs.lane_detection.common.optims.ep12_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/baseline/repvgg_b2_culane.py
+++ b/configs/lane_detection/baseline/repvgg_b2_culane.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.culane_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
-from configs.lane_detection.common.datasets.test_288 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.culane_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
+    from configs.lane_detection.common.datasets.test_288 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.sgd02 import optimizer
-from configs.lane_detection.common.optims.ep12_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.sgd02 import optimizer
+    from configs.lane_detection.common.optims.ep12_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/baseline/resnet101_culane.py
+++ b/configs/lane_detection/baseline/resnet101_culane.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.culane_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
-from configs.lane_detection.common.datasets.test_288 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.culane_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
+    from configs.lane_detection.common.datasets.test_288 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.sgd008 import optimizer
-from configs.lane_detection.common.optims.ep12_poly_warmup500 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.sgd008 import optimizer
+    from configs.lane_detection.common.optims.ep12_poly_warmup500 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/baseline/resnet101_tusimple.py
+++ b/configs/lane_detection/baseline/resnet101_tusimple.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.tusimple_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.tusimple_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_7class import loss
-from configs.lane_detection.common.optims.sgd013 import optimizer
-from configs.lane_detection.common.optims.ep50_poly_warmup500 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_7class import loss
+    from configs.lane_detection.common.optims.sgd013 import optimizer
+    from configs.lane_detection.common.optims.ep50_poly_warmup500 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/baseline/resnet18_culane.py
+++ b/configs/lane_detection/baseline/resnet18_culane.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.culane_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
-from configs.lane_detection.common.datasets.test_288 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.culane_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
+    from configs.lane_detection.common.datasets.test_288 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.sgd02 import optimizer
-from configs.lane_detection.common.optims.ep12_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.sgd02 import optimizer
+    from configs.lane_detection.common.optims.ep12_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/baseline/resnet18_tusimple.py
+++ b/configs/lane_detection/baseline/resnet18_tusimple.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.tusimple_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.tusimple_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_7class import loss
-from configs.lane_detection.common.optims.sgd02 import optimizer
-from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_7class import loss
+    from configs.lane_detection.common.optims.sgd02 import optimizer
+    from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/baseline/resnet34_culane.py
+++ b/configs/lane_detection/baseline/resnet34_culane.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.culane_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
-from configs.lane_detection.common.datasets.test_288 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.culane_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
+    from configs.lane_detection.common.datasets.test_288 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.sgd02 import optimizer
-from configs.lane_detection.common.optims.ep12_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.sgd02 import optimizer
+    from configs.lane_detection.common.optims.ep12_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/baseline/resnet34_llamas.py
+++ b/configs/lane_detection/baseline/resnet34_llamas.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.llamas_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.llamas_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.sgd05 import optimizer
-from configs.lane_detection.common.optims.ep18_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.sgd05 import optimizer
+    from configs.lane_detection.common.optims.ep18_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/baseline/resnet34_tusimple.py
+++ b/configs/lane_detection/baseline/resnet34_tusimple.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.tusimple_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.tusimple_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_7class import loss
-from configs.lane_detection.common.optims.sgd02 import optimizer
-from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_7class import loss
+    from configs.lane_detection.common.optims.sgd02 import optimizer
+    from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/baseline/resnet34_tusimple_aug.py
+++ b/configs/lane_detection/baseline/resnet34_tusimple_aug.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.tusimple_seg import dataset
-from configs.lane_detection.common.datasets.train_level1a_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.tusimple_seg import dataset
+    from configs.lane_detection.common.datasets.train_level1a_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_7class import loss
-from configs.lane_detection.common.optims.sgd02 import optimizer
-from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_7class import loss
+    from configs.lane_detection.common.optims.sgd02 import optimizer
+    from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/baseline/resnet50_culane.py
+++ b/configs/lane_detection/baseline/resnet50_culane.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.culane_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
-from configs.lane_detection.common.datasets.test_288 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.culane_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
+    from configs.lane_detection.common.datasets.test_288 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.sgd008 import optimizer
-from configs.lane_detection.common.optims.ep12_poly_warmup500 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.sgd008 import optimizer
+    from configs.lane_detection.common.optims.ep12_poly_warmup500 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/baseline/resnet50_tusimple.py
+++ b/configs/lane_detection/baseline/resnet50_tusimple.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.tusimple_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.tusimple_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_7class import loss
-from configs.lane_detection.common.optims.sgd013 import optimizer
-from configs.lane_detection.common.optims.ep50_poly_warmup500 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_7class import loss
+    from configs.lane_detection.common.optims.sgd013 import optimizer
+    from configs.lane_detection.common.optims.ep50_poly_warmup500 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/baseline/swin_tiny_culane.py
+++ b/configs/lane_detection/baseline/swin_tiny_culane.py
@@ -1,11 +1,13 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.culane_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
-from configs.lane_detection.common.datasets.test_288 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.culane_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
+    from configs.lane_detection.common.datasets.test_288 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.adamw0001_swin import optimizer
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.adamw0001_swin import optimizer
 
 lr_scheduler = dict(
     name='poly_scheduler_with_warmup',

--- a/configs/lane_detection/baseline/vgg16_culane.py
+++ b/configs/lane_detection/baseline/vgg16_culane.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.culane_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
-from configs.lane_detection.common.datasets.test_288 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.culane_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
+    from configs.lane_detection.common.datasets.test_288 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.sgd02 import optimizer
-from configs.lane_detection.common.optims.ep12_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.sgd02 import optimizer
+    from configs.lane_detection.common.optims.ep12_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/baseline/vgg16_llamas.py
+++ b/configs/lane_detection/baseline/vgg16_llamas.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.llamas_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.llamas_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.sgd03 import optimizer
-from configs.lane_detection.common.optims.ep18_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.sgd03 import optimizer
+    from configs.lane_detection.common.optims.ep18_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/baseline/vgg16_tusimple.py
+++ b/configs/lane_detection/baseline/vgg16_tusimple.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.tusimple_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.tusimple_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_7class import loss
-from configs.lane_detection.common.optims.sgd025 import optimizer
-from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_7class import loss
+    from configs.lane_detection.common.optims.sgd025 import optimizer
+    from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/bezierlanenet/resnet18_culane_aug1b.py
+++ b/configs/lane_detection/bezierlanenet/resnet18_culane_aug1b.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.culane_bezier import dataset
-from configs.lane_detection.common.datasets.train_level1b_288 import train_augmentation
-from configs.lane_detection.common.datasets.test_288 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.culane_bezier import dataset
+    from configs.lane_detection.common.datasets.train_level1b_288 import train_augmentation
+    from configs.lane_detection.common.datasets.test_288 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.matchingloss_bezier import loss
-from configs.lane_detection.common.optims.adam00006_dcn import optimizer
-from configs.lane_detection.common.optims.ep36_cosine import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.matchingloss_bezier import loss
+    from configs.lane_detection.common.optims.adam00006_dcn import optimizer
+    from configs.lane_detection.common.optims.ep36_cosine import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/bezierlanenet/resnet18_llamas_aug1b.py
+++ b/configs/lane_detection/bezierlanenet/resnet18_llamas_aug1b.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.llamas_bezier import dataset
-from configs.lane_detection.common.datasets.train_level1b_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.llamas_bezier import dataset
+    from configs.lane_detection.common.datasets.train_level1b_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.matchingloss_bezier import loss
-from configs.lane_detection.common.optims.adam00006_dcn import optimizer
-from configs.lane_detection.common.optims.ep20_cosine import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.matchingloss_bezier import loss
+    from configs.lane_detection.common.optims.adam00006_dcn import optimizer
+    from configs.lane_detection.common.optims.ep20_cosine import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/bezierlanenet/resnet18_tusimple_aug1b.py
+++ b/configs/lane_detection/bezierlanenet/resnet18_tusimple_aug1b.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.tusimple_bezier import dataset
-from configs.lane_detection.common.datasets.train_level1b_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.tusimple_bezier import dataset
+    from configs.lane_detection.common.datasets.train_level1b_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.matchingloss_bezier import loss
-from configs.lane_detection.common.optims.adam00006_dcn import optimizer
-from configs.lane_detection.common.optims.ep400_cosine import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.matchingloss_bezier import loss
+    from configs.lane_detection.common.optims.adam00006_dcn import optimizer
+    from configs.lane_detection.common.optims.ep400_cosine import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/bezierlanenet/resnet34_culane_aug1b.py
+++ b/configs/lane_detection/bezierlanenet/resnet34_culane_aug1b.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.culane_bezier import dataset
-from configs.lane_detection.common.datasets.train_level1b_288 import train_augmentation
-from configs.lane_detection.common.datasets.test_288 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.culane_bezier import dataset
+    from configs.lane_detection.common.datasets.train_level1b_288 import train_augmentation
+    from configs.lane_detection.common.datasets.test_288 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.matchingloss_bezier import loss
-from configs.lane_detection.common.optims.adam00006_dcn import optimizer
-from configs.lane_detection.common.optims.ep36_cosine import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.matchingloss_bezier import loss
+    from configs.lane_detection.common.optims.adam00006_dcn import optimizer
+    from configs.lane_detection.common.optims.ep36_cosine import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/bezierlanenet/resnet34_llamas_aug1b.py
+++ b/configs/lane_detection/bezierlanenet/resnet34_llamas_aug1b.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.llamas_bezier import dataset
-from configs.lane_detection.common.datasets.train_level1b_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.llamas_bezier import dataset
+    from configs.lane_detection.common.datasets.train_level1b_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.matchingloss_bezier import loss
-from configs.lane_detection.common.optims.adam00006_dcn import optimizer
-from configs.lane_detection.common.optims.ep20_cosine import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.matchingloss_bezier import loss
+    from configs.lane_detection.common.optims.adam00006_dcn import optimizer
+    from configs.lane_detection.common.optims.ep20_cosine import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/bezierlanenet/resnet34_tusimple_aug1b.py
+++ b/configs/lane_detection/bezierlanenet/resnet34_tusimple_aug1b.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.tusimple_bezier import dataset
-from configs.lane_detection.common.datasets.train_level1b_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.tusimple_bezier import dataset
+    from configs.lane_detection.common.datasets.train_level1b_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.matchingloss_bezier import loss
-from configs.lane_detection.common.optims.adam00006_dcn import optimizer
-from configs.lane_detection.common.optims.ep400_cosine import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.matchingloss_bezier import loss
+    from configs.lane_detection.common.optims.adam00006_dcn import optimizer
+    from configs.lane_detection.common.optims.ep400_cosine import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/bezierlanenet/vis_resnet34_culane_aug1b.py
+++ b/configs/lane_detection/bezierlanenet/vis_resnet34_culane_aug1b.py
@@ -1,9 +1,11 @@
-# 1. Import from the corresponding config
-# Or you can just copy-paste (if your config filename includes - or something)
-from configs.lane_detection.bezierlanenet.resnet34_culane_aug1b import *
+from importmagician import import_from
+with import_from('./'):
+    # 1. Import from the corresponding config
+    # Or you can just copy-paste (if your config filename includes - or something)
+    from configs.lane_detection.bezierlanenet.resnet34_culane_aug1b import *
 
-# 2. Define vis_dataset
-from configs.lane_detection.common.datasets._utils import CULANE_ROOT
+    # 2. Define vis_dataset
+    from configs.lane_detection.common.datasets._utils import CULANE_ROOT
 
 vis_dataset = dict(
     name='CULaneVis',

--- a/configs/lane_detection/bezierlanenet/vis_resnet34_tusimple_aug1b.py
+++ b/configs/lane_detection/bezierlanenet/vis_resnet34_tusimple_aug1b.py
@@ -1,9 +1,11 @@
-# 1. Import from the corresponding config
-# Or you can just copy-paste (if your config filename includes - or something)
-from configs.lane_detection.bezierlanenet.resnet34_tusimple_aug1b import *
+from importmagician import import_from
+with import_from('./'):
+    # 1. Import from the corresponding config
+    # Or you can just copy-paste (if your config filename includes - or something)
+    from configs.lane_detection.bezierlanenet.resnet34_tusimple_aug1b import *
 
-# 2. Define vis_dataset
-from configs.lane_detection.common.datasets._utils import TUSIMPLE_ROOT
+    # 2. Define vis_dataset
+    from configs.lane_detection.common.datasets._utils import TUSIMPLE_ROOT
 
 vis_dataset = dict(
     name='TuSimpleVis',

--- a/configs/lane_detection/lstr/resnet18s_culane.py
+++ b/configs/lane_detection/lstr/resnet18s_culane.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.culane import dataset
-from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
-from configs.lane_detection.common.datasets.test_288 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.culane import dataset
+    from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
+    from configs.lane_detection.common.datasets.test_288 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.matchingloss_polynomial import loss
-from configs.lane_detection.common.optims.adam000025 import optimizer
-from configs.lane_detection.common.optims.ep150_step import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.matchingloss_polynomial import loss
+    from configs.lane_detection.common.optims.adam000025 import optimizer
+    from configs.lane_detection.common.optims.ep150_step import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/lstr/resnet18s_culane_aug.py
+++ b/configs/lane_detection/lstr/resnet18s_culane_aug.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.culane import dataset
-from configs.lane_detection.common.datasets.train_level1a_288 import train_augmentation
-from configs.lane_detection.common.datasets.test_288 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.culane import dataset
+    from configs.lane_detection.common.datasets.train_level1a_288 import train_augmentation
+    from configs.lane_detection.common.datasets.test_288 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.matchingloss_polynomial import loss
-from configs.lane_detection.common.optims.adam000025 import optimizer
-from configs.lane_detection.common.optims.ep150_step import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.matchingloss_polynomial import loss
+    from configs.lane_detection.common.optims.adam000025 import optimizer
+    from configs.lane_detection.common.optims.ep150_step import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/lstr/resnet18s_tusimple.py
+++ b/configs/lane_detection/lstr/resnet18s_tusimple.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.tusimple import dataset
-from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.tusimple import dataset
+    from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.matchingloss_polynomial import loss
-from configs.lane_detection.common.optims.adam000025 import optimizer
-from configs.lane_detection.common.optims.ep2000_step import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.matchingloss_polynomial import loss
+    from configs.lane_detection.common.optims.adam000025 import optimizer
+    from configs.lane_detection.common.optims.ep2000_step import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/lstr/resnet18s_tusimple_aug.py
+++ b/configs/lane_detection/lstr/resnet18s_tusimple_aug.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.tusimple import dataset
-from configs.lane_detection.common.datasets.train_level1a_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.tusimple import dataset
+    from configs.lane_detection.common.datasets.train_level1a_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.matchingloss_polynomial import loss
-from configs.lane_detection.common.optims.adam000025 import optimizer
-from configs.lane_detection.common.optims.ep2000_step import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.matchingloss_polynomial import loss
+    from configs.lane_detection.common.optims.adam000025 import optimizer
+    from configs.lane_detection.common.optims.ep2000_step import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/lstr/resnet34_culane_aug.py
+++ b/configs/lane_detection/lstr/resnet34_culane_aug.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.culane import dataset
-from configs.lane_detection.common.datasets.train_level1a_288 import train_augmentation
-from configs.lane_detection.common.datasets.test_288 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.culane import dataset
+    from configs.lane_detection.common.datasets.train_level1a_288 import train_augmentation
+    from configs.lane_detection.common.datasets.test_288 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.matchingloss_polynomial import loss
-from configs.lane_detection.common.optims.adam000025 import optimizer
-from configs.lane_detection.common.optims.ep150_step import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.matchingloss_polynomial import loss
+    from configs.lane_detection.common.optims.adam000025 import optimizer
+    from configs.lane_detection.common.optims.ep150_step import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/resa/erfnet_culane.py
+++ b/configs/lane_detection/resa/erfnet_culane.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.culane_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
-from configs.lane_detection.common.datasets.test_288 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.culane_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
+    from configs.lane_detection.common.datasets.test_288 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.sgd01 import optimizer
-from configs.lane_detection.common.optims.ep12_poly_warmup500 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.sgd01 import optimizer
+    from configs.lane_detection.common.optims.ep12_poly_warmup500 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/resa/erfnet_tusimple.py
+++ b/configs/lane_detection/resa/erfnet_tusimple.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.tusimple_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.tusimple_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_7class import loss
-from configs.lane_detection.common.optims.sgd01 import optimizer
-from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_7class import loss
+    from configs.lane_detection.common.optims.sgd01 import optimizer
+    from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/resa/mobilenetv2_culane.py
+++ b/configs/lane_detection/resa/mobilenetv2_culane.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.culane_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
-from configs.lane_detection.common.datasets.test_288 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.culane_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
+    from configs.lane_detection.common.datasets.test_288 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.sgd006 import optimizer
-from configs.lane_detection.common.optims.ep12_poly_warmup500 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.sgd006 import optimizer
+    from configs.lane_detection.common.optims.ep12_poly_warmup500 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/resa/mobilenetv2_tusimple.py
+++ b/configs/lane_detection/resa/mobilenetv2_tusimple.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.tusimple_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.tusimple_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_7class import loss
-from configs.lane_detection.common.optims.sgd006 import optimizer
-from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_7class import loss
+    from configs.lane_detection.common.optims.sgd006 import optimizer
+    from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/resa/mobilenetv3_large_culane.py
+++ b/configs/lane_detection/resa/mobilenetv3_large_culane.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.culane_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
-from configs.lane_detection.common.datasets.test_288 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.culane_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
+    from configs.lane_detection.common.datasets.test_288 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.sgd006 import optimizer
-from configs.lane_detection.common.optims.ep12_poly_warmup500 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.sgd006 import optimizer
+    from configs.lane_detection.common.optims.ep12_poly_warmup500 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/resa/mobilenetv3_large_tusimple.py
+++ b/configs/lane_detection/resa/mobilenetv3_large_tusimple.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.tusimple_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.tusimple_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_7class import loss
-from configs.lane_detection.common.optims.sgd006 import optimizer
-from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_7class import loss
+    from configs.lane_detection.common.optims.sgd006 import optimizer
+    from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/resa/resnet101_culane.py
+++ b/configs/lane_detection/resa/resnet101_culane.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.culane_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
-from configs.lane_detection.common.datasets.test_288 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.culane_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
+    from configs.lane_detection.common.datasets.test_288 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.sgd0048 import optimizer
-from configs.lane_detection.common.optims.ep12_poly_warmup600 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.sgd0048 import optimizer
+    from configs.lane_detection.common.optims.ep12_poly_warmup600 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/resa/resnet101_tusimple.py
+++ b/configs/lane_detection/resa/resnet101_tusimple.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.tusimple_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.tusimple_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_7class import loss
-from configs.lane_detection.common.optims.sgd0048 import optimizer
-from configs.lane_detection.common.optims.ep50_poly_warmup250 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_7class import loss
+    from configs.lane_detection.common.optims.sgd0048 import optimizer
+    from configs.lane_detection.common.optims.ep50_poly_warmup250 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/resa/resnet18_culane.py
+++ b/configs/lane_detection/resa/resnet18_culane.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.culane_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
-from configs.lane_detection.common.datasets.test_288 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.culane_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
+    from configs.lane_detection.common.datasets.test_288 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.sgd006 import optimizer
-from configs.lane_detection.common.optims.ep12_poly_warmup500 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.sgd006 import optimizer
+    from configs.lane_detection.common.optims.ep12_poly_warmup500 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/resa/resnet18_tusimple.py
+++ b/configs/lane_detection/resa/resnet18_tusimple.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.tusimple_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.tusimple_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_7class import loss
-from configs.lane_detection.common.optims.sgd006 import optimizer
-from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_7class import loss
+    from configs.lane_detection.common.optims.sgd006 import optimizer
+    from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/resa/resnet34_culane.py
+++ b/configs/lane_detection/resa/resnet34_culane.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.culane_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
-from configs.lane_detection.common.datasets.test_288 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.culane_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
+    from configs.lane_detection.common.datasets.test_288 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.sgd006 import optimizer
-from configs.lane_detection.common.optims.ep12_poly_warmup500 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.sgd006 import optimizer
+    from configs.lane_detection.common.optims.ep12_poly_warmup500 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/resa/resnet34_tusimple.py
+++ b/configs/lane_detection/resa/resnet34_tusimple.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.tusimple_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.tusimple_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_7class import loss
-from configs.lane_detection.common.optims.sgd006 import optimizer
-from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_7class import loss
+    from configs.lane_detection.common.optims.sgd006 import optimizer
+    from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/resa/resnet50_culane.py
+++ b/configs/lane_detection/resa/resnet50_culane.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.culane_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
-from configs.lane_detection.common.datasets.test_288 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.culane_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
+    from configs.lane_detection.common.datasets.test_288 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.sgd006 import optimizer
-from configs.lane_detection.common.optims.ep12_poly_warmup500 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.sgd006 import optimizer
+    from configs.lane_detection.common.optims.ep12_poly_warmup500 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/resa/resnet50_tusimple.py
+++ b/configs/lane_detection/resa/resnet50_tusimple.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.tusimple_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.tusimple_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_7class import loss
-from configs.lane_detection.common.optims.sgd006 import optimizer
-from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_7class import loss
+    from configs.lane_detection.common.optims.sgd006 import optimizer
+    from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/scnn/erfnet_culane.py
+++ b/configs/lane_detection/scnn/erfnet_culane.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.culane_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
-from configs.lane_detection.common.datasets.test_288 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.culane_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
+    from configs.lane_detection.common.datasets.test_288 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.sgd02 import optimizer
-from configs.lane_detection.common.optims.ep12_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.sgd02 import optimizer
+    from configs.lane_detection.common.optims.ep12_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/scnn/erfnet_llamas.py
+++ b/configs/lane_detection/scnn/erfnet_llamas.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.llamas_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.llamas_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.sgd05 import optimizer
-from configs.lane_detection.common.optims.ep10_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.sgd05 import optimizer
+    from configs.lane_detection.common.optims.ep10_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/scnn/erfnet_tusimple.py
+++ b/configs/lane_detection/scnn/erfnet_tusimple.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.tusimple_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.tusimple_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_7class import loss
-from configs.lane_detection.common.optims.sgd02 import optimizer
-from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_7class import loss
+    from configs.lane_detection.common.optims.sgd02 import optimizer
+    from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/scnn/erfnet_tusimple_aug.py
+++ b/configs/lane_detection/scnn/erfnet_tusimple_aug.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.tusimple_seg import dataset
-from configs.lane_detection.common.datasets.train_level1a_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.tusimple_seg import dataset
+    from configs.lane_detection.common.datasets.train_level1a_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_7class import loss
-from configs.lane_detection.common.optims.sgd02 import optimizer
-from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_7class import loss
+    from configs.lane_detection.common.optims.sgd02 import optimizer
+    from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/scnn/mobilenetv2_culane.py
+++ b/configs/lane_detection/scnn/mobilenetv2_culane.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.culane_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
-from configs.lane_detection.common.datasets.test_288 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.culane_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
+    from configs.lane_detection.common.datasets.test_288 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.sgd02 import optimizer
-from configs.lane_detection.common.optims.ep12_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.sgd02 import optimizer
+    from configs.lane_detection.common.optims.ep12_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/scnn/mobilenetv2_tusimple.py
+++ b/configs/lane_detection/scnn/mobilenetv2_tusimple.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.tusimple_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.tusimple_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_7class import loss
-from configs.lane_detection.common.optims.sgd02 import optimizer
-from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_7class import loss
+    from configs.lane_detection.common.optims.sgd02 import optimizer
+    from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/scnn/repvgg_a1_culane.py
+++ b/configs/lane_detection/scnn/repvgg_a1_culane.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.culane_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
-from configs.lane_detection.common.datasets.test_288 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.culane_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
+    from configs.lane_detection.common.datasets.test_288 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.sgd01 import optimizer
-from configs.lane_detection.common.optims.ep12_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.sgd01 import optimizer
+    from configs.lane_detection.common.optims.ep12_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/scnn/resnet101_culane.py
+++ b/configs/lane_detection/scnn/resnet101_culane.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.culane_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
-from configs.lane_detection.common.datasets.test_288 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.culane_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
+    from configs.lane_detection.common.datasets.test_288 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.sgd008 import optimizer
-from configs.lane_detection.common.optims.ep12_poly_warmup500 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.sgd008 import optimizer
+    from configs.lane_detection.common.optims.ep12_poly_warmup500 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/scnn/resnet101_tusimple.py
+++ b/configs/lane_detection/scnn/resnet101_tusimple.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.tusimple_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.tusimple_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_7class import loss
-from configs.lane_detection.common.optims.sgd013 import optimizer
-from configs.lane_detection.common.optims.ep50_poly_warmup500 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_7class import loss
+    from configs.lane_detection.common.optims.sgd013 import optimizer
+    from configs.lane_detection.common.optims.ep50_poly_warmup500 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/scnn/resnet18_culane.py
+++ b/configs/lane_detection/scnn/resnet18_culane.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.culane_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
-from configs.lane_detection.common.datasets.test_288 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.culane_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
+    from configs.lane_detection.common.datasets.test_288 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.sgd02 import optimizer
-from configs.lane_detection.common.optims.ep12_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.sgd02 import optimizer
+    from configs.lane_detection.common.optims.ep12_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/scnn/resnet18_tusimple.py
+++ b/configs/lane_detection/scnn/resnet18_tusimple.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.tusimple_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.tusimple_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_7class import loss
-from configs.lane_detection.common.optims.sgd02 import optimizer
-from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_7class import loss
+    from configs.lane_detection.common.optims.sgd02 import optimizer
+    from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/scnn/resnet34_culane.py
+++ b/configs/lane_detection/scnn/resnet34_culane.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.culane_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
-from configs.lane_detection.common.datasets.test_288 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.culane_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
+    from configs.lane_detection.common.datasets.test_288 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.sgd02 import optimizer
-from configs.lane_detection.common.optims.ep12_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.sgd02 import optimizer
+    from configs.lane_detection.common.optims.ep12_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/scnn/resnet34_llamas.py
+++ b/configs/lane_detection/scnn/resnet34_llamas.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.llamas_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.llamas_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.sgd01 import optimizer
-from configs.lane_detection.common.optims.ep18_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.sgd01 import optimizer
+    from configs.lane_detection.common.optims.ep18_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/scnn/resnet34_tusimple.py
+++ b/configs/lane_detection/scnn/resnet34_tusimple.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.tusimple_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.tusimple_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_7class import loss
-from configs.lane_detection.common.optims.sgd02 import optimizer
-from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_7class import loss
+    from configs.lane_detection.common.optims.sgd02 import optimizer
+    from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/scnn/resnet34_tusimple_aug.py
+++ b/configs/lane_detection/scnn/resnet34_tusimple_aug.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.tusimple_seg import dataset
-from configs.lane_detection.common.datasets.train_level1a_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.tusimple_seg import dataset
+    from configs.lane_detection.common.datasets.train_level1a_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_7class import loss
-from configs.lane_detection.common.optims.sgd02 import optimizer
-from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_7class import loss
+    from configs.lane_detection.common.optims.sgd02 import optimizer
+    from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/scnn/resnet50_culane.py
+++ b/configs/lane_detection/scnn/resnet50_culane.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.culane_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
-from configs.lane_detection.common.datasets.test_288 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.culane_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
+    from configs.lane_detection.common.datasets.test_288 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.sgd008 import optimizer
-from configs.lane_detection.common.optims.ep12_poly_warmup500 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.sgd008 import optimizer
+    from configs.lane_detection.common.optims.ep12_poly_warmup500 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/scnn/resnet50_tusimple.py
+++ b/configs/lane_detection/scnn/resnet50_tusimple.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.tusimple_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.tusimple_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_7class import loss
-from configs.lane_detection.common.optims.sgd013 import optimizer
-from configs.lane_detection.common.optims.ep50_poly_warmup500 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_7class import loss
+    from configs.lane_detection.common.optims.sgd013 import optimizer
+    from configs.lane_detection.common.optims.ep50_poly_warmup500 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/scnn/vgg16_culane.py
+++ b/configs/lane_detection/scnn/vgg16_culane.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.culane_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
-from configs.lane_detection.common.datasets.test_288 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.culane_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
+    from configs.lane_detection.common.datasets.test_288 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.sgd03 import optimizer
-from configs.lane_detection.common.optims.ep12_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.sgd03 import optimizer
+    from configs.lane_detection.common.optims.ep12_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/scnn/vgg16_llamas.py
+++ b/configs/lane_detection/scnn/vgg16_llamas.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.llamas_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.llamas_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.sgd03 import optimizer
-from configs.lane_detection.common.optims.ep18_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.sgd03 import optimizer
+    from configs.lane_detection.common.optims.ep18_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/scnn/vgg16_tusimple.py
+++ b/configs/lane_detection/scnn/vgg16_tusimple.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.tusimple_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
-from configs.lane_detection.common.datasets.test_360 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.tusimple_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_360 import train_augmentation
+    from configs.lane_detection.common.datasets.test_360 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_7class import loss
-from configs.lane_detection.common.optims.sgd035 import optimizer
-from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_7class import loss
+    from configs.lane_detection.common.optims.sgd035 import optimizer
+    from configs.lane_detection.common.optims.ep50_poly_warmup200 import lr_scheduler
 
 
 train = dict(

--- a/configs/lane_detection/upernet/swin_tiny_culane.py
+++ b/configs/lane_detection/upernet/swin_tiny_culane.py
@@ -1,11 +1,13 @@
-# Data pipeline
-from configs.lane_detection.common.datasets.culane_seg import dataset
-from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
-from configs.lane_detection.common.datasets.test_288 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.lane_detection.common.datasets.culane_seg import dataset
+    from configs.lane_detection.common.datasets.train_level0_288 import train_augmentation
+    from configs.lane_detection.common.datasets.test_288 import test_augmentation
 
-# Optimization pipeline
-from configs.lane_detection.common.optims.segloss_5class import loss
-from configs.lane_detection.common.optims.adamw0001_swin import optimizer
+    # Optimization pipeline
+    from configs.lane_detection.common.optims.segloss_5class import loss
+    from configs.lane_detection.common.optims.adamw0001_swin import optimizer
 
 
 lr_scheduler = dict(

--- a/configs/semantic_segmentation/deeplabv2/resnet101_cityscapes_256x512.py
+++ b/configs/semantic_segmentation/deeplabv2/resnet101_cityscapes_256x512.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.semantic_segmentation.common.datasets.cityscapes import dataset
-from configs.semantic_segmentation.common.datasets.city_train_half_256 import train_augmentation
-from configs.semantic_segmentation.common.datasets.city_test_half import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.semantic_segmentation.common.datasets.cityscapes import dataset
+    from configs.semantic_segmentation.common.datasets.city_train_half_256 import train_augmentation
+    from configs.semantic_segmentation.common.datasets.city_test_half import test_augmentation
 
-# Optimization pipeline
-from configs.semantic_segmentation.common.optims.celoss import loss
-from configs.semantic_segmentation.common.optims.sgd0004 import optimizer
-from configs.semantic_segmentation.common.optims.ep60 import lr_scheduler
+    # Optimization pipeline
+    from configs.semantic_segmentation.common.optims.celoss import loss
+    from configs.semantic_segmentation.common.optims.sgd0004 import optimizer
+    from configs.semantic_segmentation.common.optims.ep60 import lr_scheduler
 
 
 train = dict(

--- a/configs/semantic_segmentation/deeplabv2/resnet101_cityscapes_512x1024.py
+++ b/configs/semantic_segmentation/deeplabv2/resnet101_cityscapes_512x1024.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.semantic_segmentation.common.datasets.cityscapes import dataset
-from configs.semantic_segmentation.common.datasets.city_train_hd_512 import train_augmentation
-from configs.semantic_segmentation.common.datasets.city_test_hd import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.semantic_segmentation.common.datasets.cityscapes import dataset
+    from configs.semantic_segmentation.common.datasets.city_train_hd_512 import train_augmentation
+    from configs.semantic_segmentation.common.datasets.city_test_hd import test_augmentation
 
-# Optimization pipeline
-from configs.semantic_segmentation.common.optims.celoss import loss
-from configs.semantic_segmentation.common.optims.sgd0002 import optimizer
-from configs.semantic_segmentation.common.optims.ep60 import lr_scheduler
+    # Optimization pipeline
+    from configs.semantic_segmentation.common.optims.celoss import loss
+    from configs.semantic_segmentation.common.optims.sgd0002 import optimizer
+    from configs.semantic_segmentation.common.optims.ep60 import lr_scheduler
 
 
 train = dict(

--- a/configs/semantic_segmentation/deeplabv2/resnet101_gtav_512x1024.py
+++ b/configs/semantic_segmentation/deeplabv2/resnet101_gtav_512x1024.py
@@ -1,15 +1,17 @@
-# Data pipeline
-from configs.semantic_segmentation.common.datasets.gtav import dataset
-from configs.semantic_segmentation.common.datasets.gtav_train_hd_512 import train_augmentation
-from configs.semantic_segmentation.common.datasets.city_test_hd import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.semantic_segmentation.common.datasets.gtav import dataset
+    from configs.semantic_segmentation.common.datasets.gtav_train_hd_512 import train_augmentation
+    from configs.semantic_segmentation.common.datasets.city_test_hd import test_augmentation
 
 # For UDA baseline setting (train on GTAV, test on Cityscapes)
-from configs.semantic_segmentation.common.datasets.cityscapes import dataset as test_dataset
+    from configs.semantic_segmentation.common.datasets.cityscapes import dataset as test_dataset
 
-# Optimization pipeline
-from configs.semantic_segmentation.common.optims.celoss import loss
-from configs.semantic_segmentation.common.optims.sgd0002 import optimizer
-from configs.semantic_segmentation.common.optims.ep10 import lr_scheduler
+    # Optimization pipeline
+    from configs.semantic_segmentation.common.optims.celoss import loss
+    from configs.semantic_segmentation.common.optims.sgd0002 import optimizer
+    from configs.semantic_segmentation.common.optims.ep10 import lr_scheduler
 
 
 train = dict(

--- a/configs/semantic_segmentation/deeplabv2/resnet101_pascalvoc_321x321.py
+++ b/configs/semantic_segmentation/deeplabv2/resnet101_pascalvoc_321x321.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.semantic_segmentation.common.datasets.pascal_voc import dataset
-from configs.semantic_segmentation.common.datasets.voc_train_321 import train_augmentation
-from configs.semantic_segmentation.common.datasets.voc_test_505 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.semantic_segmentation.common.datasets.pascal_voc import dataset
+    from configs.semantic_segmentation.common.datasets.voc_train_321 import train_augmentation
+    from configs.semantic_segmentation.common.datasets.voc_test_505 import test_augmentation
 
-# Optimization pipeline
-from configs.semantic_segmentation.common.optims.celoss import loss
-from configs.semantic_segmentation.common.optims.sgd0002 import optimizer
-from configs.semantic_segmentation.common.optims.ep30 import lr_scheduler
+    # Optimization pipeline
+    from configs.semantic_segmentation.common.optims.celoss import loss
+    from configs.semantic_segmentation.common.optims.sgd0002 import optimizer
+    from configs.semantic_segmentation.common.optims.ep30 import lr_scheduler
 
 
 train = dict(

--- a/configs/semantic_segmentation/deeplabv2/resnet101_synthia_512x1024.py
+++ b/configs/semantic_segmentation/deeplabv2/resnet101_synthia_512x1024.py
@@ -1,15 +1,17 @@
-# Data pipeline
-from configs.semantic_segmentation.common.datasets.synthia import dataset
-from configs.semantic_segmentation.common.datasets.synthia_train_hd_512 import train_augmentation
-from configs.semantic_segmentation.common.datasets.city_test_hd import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.semantic_segmentation.common.datasets.synthia import dataset
+    from configs.semantic_segmentation.common.datasets.synthia_train_hd_512 import train_augmentation
+    from configs.semantic_segmentation.common.datasets.city_test_hd import test_augmentation
 
 # For UDA baseline setting (train on SYNTHIA, test on Cityscapes)
-from configs.semantic_segmentation.common.datasets.cityscapes import dataset as test_dataset
+    from configs.semantic_segmentation.common.datasets.cityscapes import dataset as test_dataset
 
-# Optimization pipeline
-from configs.semantic_segmentation.common.optims.celoss import loss
-from configs.semantic_segmentation.common.optims.sgd0002 import optimizer
-from configs.semantic_segmentation.common.optims.ep20 import lr_scheduler
+    # Optimization pipeline
+    from configs.semantic_segmentation.common.optims.celoss import loss
+    from configs.semantic_segmentation.common.optims.sgd0002 import optimizer
+    from configs.semantic_segmentation.common.optims.ep20 import lr_scheduler
 
 
 train = dict(

--- a/configs/semantic_segmentation/deeplabv3/resnet101_cityscapes_256x512.py
+++ b/configs/semantic_segmentation/deeplabv3/resnet101_cityscapes_256x512.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.semantic_segmentation.common.datasets.cityscapes import dataset
-from configs.semantic_segmentation.common.datasets.city_train_half_256 import train_augmentation
-from configs.semantic_segmentation.common.datasets.city_test_half import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.semantic_segmentation.common.datasets.cityscapes import dataset
+    from configs.semantic_segmentation.common.datasets.city_train_half_256 import train_augmentation
+    from configs.semantic_segmentation.common.datasets.city_test_half import test_augmentation
 
-# Optimization pipeline
-from configs.semantic_segmentation.common.optims.celoss import loss
-from configs.semantic_segmentation.common.optims.sgd0004 import optimizer
-from configs.semantic_segmentation.common.optims.ep60 import lr_scheduler
+    # Optimization pipeline
+    from configs.semantic_segmentation.common.optims.celoss import loss
+    from configs.semantic_segmentation.common.optims.sgd0004 import optimizer
+    from configs.semantic_segmentation.common.optims.ep60 import lr_scheduler
 
 
 train = dict(

--- a/configs/semantic_segmentation/deeplabv3/resnet101_cityscapes_512x1024.py
+++ b/configs/semantic_segmentation/deeplabv3/resnet101_cityscapes_512x1024.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.semantic_segmentation.common.datasets.cityscapes import dataset
-from configs.semantic_segmentation.common.datasets.city_train_hd_512 import train_augmentation
-from configs.semantic_segmentation.common.datasets.city_test_hd import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.semantic_segmentation.common.datasets.cityscapes import dataset
+    from configs.semantic_segmentation.common.datasets.city_train_hd_512 import train_augmentation
+    from configs.semantic_segmentation.common.datasets.city_test_hd import test_augmentation
 
-# Optimization pipeline
-from configs.semantic_segmentation.common.optims.celoss import loss
-from configs.semantic_segmentation.common.optims.sgd0002 import optimizer
-from configs.semantic_segmentation.common.optims.ep60 import lr_scheduler
+    # Optimization pipeline
+    from configs.semantic_segmentation.common.optims.celoss import loss
+    from configs.semantic_segmentation.common.optims.sgd0002 import optimizer
+    from configs.semantic_segmentation.common.optims.ep60 import lr_scheduler
 
 
 train = dict(

--- a/configs/semantic_segmentation/deeplabv3/resnet101_pascalvoc_321x321.py
+++ b/configs/semantic_segmentation/deeplabv3/resnet101_pascalvoc_321x321.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.semantic_segmentation.common.datasets.pascal_voc import dataset
-from configs.semantic_segmentation.common.datasets.voc_train_321 import train_augmentation
-from configs.semantic_segmentation.common.datasets.voc_test_505 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.semantic_segmentation.common.datasets.pascal_voc import dataset
+    from configs.semantic_segmentation.common.datasets.voc_train_321 import train_augmentation
+    from configs.semantic_segmentation.common.datasets.voc_test_505 import test_augmentation
 
-# Optimization pipeline
-from configs.semantic_segmentation.common.optims.celoss import loss
-from configs.semantic_segmentation.common.optims.sgd0002 import optimizer
-from configs.semantic_segmentation.common.optims.ep30 import lr_scheduler
+    # Optimization pipeline
+    from configs.semantic_segmentation.common.optims.celoss import loss
+    from configs.semantic_segmentation.common.optims.sgd0002 import optimizer
+    from configs.semantic_segmentation.common.optims.ep30 import lr_scheduler
 
 
 train = dict(

--- a/configs/semantic_segmentation/enet/cityscapes_512x1024.py
+++ b/configs/semantic_segmentation/enet/cityscapes_512x1024.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.semantic_segmentation.common.datasets.cityscapes import dataset
-from configs.semantic_segmentation.common.datasets.city_train_half_512_wo_norm import train_augmentation
-from configs.semantic_segmentation.common.datasets.city_test_half_wo_norm import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.semantic_segmentation.common.datasets.cityscapes import dataset
+    from configs.semantic_segmentation.common.datasets.city_train_half_512_wo_norm import train_augmentation
+    from configs.semantic_segmentation.common.datasets.city_test_half_wo_norm import test_augmentation
 
-# Optimization pipeline
-from configs.semantic_segmentation.common.optims.celoss_cityscapes_balanced import loss
-from configs.semantic_segmentation.common.optims.adam00008_wd00002 import optimizer
-from configs.semantic_segmentation.common.optims.ep300 import lr_scheduler
+    # Optimization pipeline
+    from configs.semantic_segmentation.common.optims.celoss_cityscapes_balanced import loss
+    from configs.semantic_segmentation.common.optims.adam00008_wd00002 import optimizer
+    from configs.semantic_segmentation.common.optims.ep300 import lr_scheduler
 
 
 train = dict(

--- a/configs/semantic_segmentation/enet/cityscapes_512x1024_encoder.py
+++ b/configs/semantic_segmentation/enet/cityscapes_512x1024_encoder.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.semantic_segmentation.common.datasets.cityscapes import dataset
-from configs.semantic_segmentation.common.datasets.city_train_half_512_wo_norm import train_augmentation
-from configs.semantic_segmentation.common.datasets.city_test_half_wo_norm import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.semantic_segmentation.common.datasets.cityscapes import dataset
+    from configs.semantic_segmentation.common.datasets.city_train_half_512_wo_norm import train_augmentation
+    from configs.semantic_segmentation.common.datasets.city_test_half_wo_norm import test_augmentation
 
-# Optimization pipeline
-from configs.semantic_segmentation.common.optims.celoss_cityscapes_balanced import loss
-from configs.semantic_segmentation.common.optims.adam00008_wd00002 import optimizer
-from configs.semantic_segmentation.common.optims.ep300 import lr_scheduler
+    # Optimization pipeline
+    from configs.semantic_segmentation.common.optims.celoss_cityscapes_balanced import loss
+    from configs.semantic_segmentation.common.optims.adam00008_wd00002 import optimizer
+    from configs.semantic_segmentation.common.optims.ep300 import lr_scheduler
 
 
 train = dict(

--- a/configs/semantic_segmentation/erfnet/cityscapes_512x1024.py
+++ b/configs/semantic_segmentation/erfnet/cityscapes_512x1024.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.semantic_segmentation.common.datasets.cityscapes import dataset
-from configs.semantic_segmentation.common.datasets.city_train_half_512_wo_norm import train_augmentation
-from configs.semantic_segmentation.common.datasets.city_test_half_wo_norm import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.semantic_segmentation.common.datasets.cityscapes import dataset
+    from configs.semantic_segmentation.common.datasets.city_train_half_512_wo_norm import train_augmentation
+    from configs.semantic_segmentation.common.datasets.city_test_half_wo_norm import test_augmentation
 
-# Optimization pipeline
-from configs.semantic_segmentation.common.optims.celoss_cityscapes_balanced import loss
-from configs.semantic_segmentation.common.optims.adam00007 import optimizer
-from configs.semantic_segmentation.common.optims.ep150_epoch import lr_scheduler
+    # Optimization pipeline
+    from configs.semantic_segmentation.common.optims.celoss_cityscapes_balanced import loss
+    from configs.semantic_segmentation.common.optims.adam00007 import optimizer
+    from configs.semantic_segmentation.common.optims.ep150_epoch import lr_scheduler
 
 
 train = dict(

--- a/configs/semantic_segmentation/fcn/resnet101_cityscapes_256x512.py
+++ b/configs/semantic_segmentation/fcn/resnet101_cityscapes_256x512.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.semantic_segmentation.common.datasets.cityscapes import dataset
-from configs.semantic_segmentation.common.datasets.city_train_half_256 import train_augmentation
-from configs.semantic_segmentation.common.datasets.city_test_half import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.semantic_segmentation.common.datasets.cityscapes import dataset
+    from configs.semantic_segmentation.common.datasets.city_train_half_256 import train_augmentation
+    from configs.semantic_segmentation.common.datasets.city_test_half import test_augmentation
 
-# Optimization pipeline
-from configs.semantic_segmentation.common.optims.celoss import loss
-from configs.semantic_segmentation.common.optims.sgd0004 import optimizer
-from configs.semantic_segmentation.common.optims.ep60 import lr_scheduler
+    # Optimization pipeline
+    from configs.semantic_segmentation.common.optims.celoss import loss
+    from configs.semantic_segmentation.common.optims.sgd0004 import optimizer
+    from configs.semantic_segmentation.common.optims.ep60 import lr_scheduler
 
 
 train = dict(

--- a/configs/semantic_segmentation/fcn/resnet101_pascalvoc_321x321.py
+++ b/configs/semantic_segmentation/fcn/resnet101_pascalvoc_321x321.py
@@ -1,12 +1,14 @@
-# Data pipeline
-from configs.semantic_segmentation.common.datasets.pascal_voc import dataset
-from configs.semantic_segmentation.common.datasets.voc_train_321 import train_augmentation
-from configs.semantic_segmentation.common.datasets.voc_test_505 import test_augmentation
+from importmagician import import_from
+with import_from('./'):
+    # Data pipeline
+    from configs.semantic_segmentation.common.datasets.pascal_voc import dataset
+    from configs.semantic_segmentation.common.datasets.voc_train_321 import train_augmentation
+    from configs.semantic_segmentation.common.datasets.voc_test_505 import test_augmentation
 
-# Optimization pipeline
-from configs.semantic_segmentation.common.optims.celoss import loss
-from configs.semantic_segmentation.common.optims.sgd0002 import optimizer
-from configs.semantic_segmentation.common.optims.ep30 import lr_scheduler
+    # Optimization pipeline
+    from configs.semantic_segmentation.common.optims.celoss import loss
+    from configs.semantic_segmentation.common.optims.sgd0002 import optimizer
+    from configs.semantic_segmentation.common.optims.ep30 import lr_scheduler
 
 
 train = dict(

--- a/utils/args.py
+++ b/utils/args.py
@@ -1,4 +1,3 @@
-from msilib.schema import Class
 import os
 from importlib.machinery import SourceFileLoader
 

--- a/utils/args.py
+++ b/utils/args.py
@@ -1,3 +1,4 @@
+from msilib.schema import Class
 import os
 from importlib.machinery import SourceFileLoader
 
@@ -55,7 +56,7 @@ def read_config(config_path):
     assert module_name[-3:] == '.py'
     module_name = module_name[:-3]
     module = SourceFileLoader(module_name, config_path).load_module()
-    res = {k: v for k, v in module.__dict__.items() if not k.startswith('__')}
+    res = {k: v for k, v in module.__dict__.items() if ((not k.startswith('__')) and (not callable(k)))}
 
     return res
 


### PR DESCRIPTION
This robust import mechanism should fix the unclear import issue in #76 #84 or other related issues.

For instance, when running sud-dir py files, some would have trouble importing `configs` because somehow `cwd` is not in python path:

```
...
ModuleNotFoundError: No module named 'configs.lane_detection'
```