### PR TITLE
CULane metric python backend

### DIFF
--- a/autotest_culane.sh
+++ b/autotest_culane.sh
@@ -1,9 +1,18 @@
 #!/bin/bash
+backend="cpp"  # or python
 echo experiment name: $1
 echo status: $2
 echo save dir: $3
 
-cd tools/culane_evaluation
+if [ "${backend}" = "cpp" ]; then
+    cd tools/culane_evaluation
+else
+    echo Although python version works, we still suggest using the official Cpp version when possible!
+    echo At least try them when you are writing a paper.
+    echo Cpp and Python backends yield slightly different results.
+    cd tools/culane_evaluation_py
+fi
+
 if [ "$2" = "test" ]; then
     # Perform test with official scripts
     ./eval.sh $1 $3

--- a/docs/datasets/CULANE.md
+++ b/docs/datasets/CULANE.md
@@ -16,7 +16,7 @@
   python tools/culane_list_convertor.py
 ```
 
-4. Prepare official evaluation scripts:
+4. Prepare official evaluation scripts (**require CP++ OpenCV**):
 
 *comment Line 21 in Makefile if using opencv2.*
 
@@ -26,6 +26,17 @@ make
 mkdir output
 chmod 777 eval*
 cd -
+```
+
+Check [this issue](https://github.com/voldemortX/pytorch-auto-drive/issues/80) if you have OpenCV >= 4.0.
+
+5. Prepare python evaluation scripts (**If you have difficulty compiling in 4.**):
+
+```
+cd tools/culane_evaluation_py
+mkdir output
+chmod 777 *.sh
+# change $backend from cpp to python in autotest_culane.sh
 ```
 
 Then change `data_dir` to your CULane base directory in [eval.sh](../../tools/culane_evaluation/eval.sh) and [eval_validation.sh](../../tools/culane_evaluation/eval_validation.sh). *Mind that you need extra ../../ if relative path is used.*

--- a/tools/culane_evaluation_py/cal_total.py
+++ b/tools/culane_evaluation_py/cal_total.py
@@ -1,0 +1,46 @@
+# Accumulate and calculate whole F1 score on CULane
+
+import argparse
+import fcntl
+
+if __name__ == '__main__':
+    # Settings
+    parser = argparse.ArgumentParser(description='PyTorch 1.6.0')
+    parser.add_argument('--exp-name', type=str, default='',
+                        help='Name of experiment')
+    parser.add_argument('--save-dir', type=str, help='Path prefix to save full res.')
+    args = parser.parse_args()
+
+    filename = 'output/' + args.exp_name + '_iou0.5_split.txt'
+    with open(filename, 'r') as f:
+        temp = f.readlines()
+
+    # Count
+    tp = 0
+    fp = 0
+    fn = 0
+    for i in range(9):
+        line = temp[i * 6 + 1].replace('\n', '').split(' ')
+        tp += int(line[1])
+        fp += int(line[3])
+        fn += int(line[5])
+
+    # Calculate
+    precision = tp / (tp + fp)
+    recall = tp / (tp + fn)
+    f1 = 2 * precision * recall / (precision + recall) * 100
+
+    # Log
+    res_str = '\nF1 score: {}\nPrecision: {}\nRecall: {}\n'.format(f1, precision * 100, recall * 100)
+    print(res_str)
+    with open('../../log.txt', 'a') as f:
+        fcntl.flock(f, fcntl.LOCK_EX)
+        f.write(args.exp_name + ': ' + str(f1) + '\n')
+        fcntl.flock(f, fcntl.LOCK_UN)
+
+    if args.save_dir is not None:
+        import os
+        save_dir = os.path.join('../../', args.save_dir, args.exp_name)
+        os.makedirs(save_dir, exist_ok=True)
+        with open(os.path.join(save_dir, 'test_result.txt'), 'a') as f:
+            f.write('Total:' + res_str)

--- a/tools/culane_evaluation_py/eval.sh
+++ b/tools/culane_evaluation_py/eval.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+root=../../
+data_dir=../../../../dataset/culane/
+exp=$1
+detect_dir=../../output/
+
+# These can not be changed
+w_lane=30;
+iou=0.5;  # Set iou to 0.3 or 0.5
+im_w=1640
+im_h=590
+list0=${data_dir}list/test_split/test0_normal.txt
+list1=${data_dir}list/test_split/test1_crowd.txt
+list2=${data_dir}list/test_split/test2_hlight.txt
+list3=${data_dir}list/test_split/test3_shadow.txt
+list4=${data_dir}list/test_split/test4_noline.txt
+list5=${data_dir}list/test_split/test5_arrow.txt
+list6=${data_dir}list/test_split/test6_curve.txt
+list7=${data_dir}list/test_split/test7_cross.txt
+list8=${data_dir}list/test_split/test8_night.txt
+out0=./output/out0_normal.txt
+out1=./output/out1_crowd.txt
+out2=./output/out2_hlight.txt
+out3=./output/out3_shadow.txt
+out4=./output/out4_noline.txt
+out5=./output/out5_arrow.txt
+out6=./output/out6_curve.txt
+out7=./output/out7_cross.txt
+out8=./output/out8_night.txt
+python evaluate.py -a $data_dir -d $detect_dir -l $list0 -w $w_lane -t $iou -c $im_w -r $im_h -o $out0
+python evaluate.py -a $data_dir -d $detect_dir -l $list1 -w $w_lane -t $iou -c $im_w -r $im_h -o $out1
+python evaluate.py -a $data_dir -d $detect_dir -l $list2 -w $w_lane -t $iou -c $im_w -r $im_h -o $out2
+python evaluate.py -a $data_dir -d $detect_dir -l $list3 -w $w_lane -t $iou -c $im_w -r $im_h -o $out3
+python evaluate.py -a $data_dir -d $detect_dir -l $list4 -w $w_lane -t $iou -c $im_w -r $im_h -o $out4
+python evaluate.py -a $data_dir -d $detect_dir -l $list5 -w $w_lane -t $iou -c $im_w -r $im_h -o $out5
+python evaluate.py -a $data_dir -d $detect_dir -l $list6 -w $w_lane -t $iou -c $im_w -r $im_h -o $out6
+python evaluate.py -a $data_dir -d $detect_dir -l $list7 -w $w_lane -t $iou -c $im_w -r $im_h -o $out7
+python evaluate.py -a $data_dir -d $detect_dir -l $list8 -w $w_lane -t $iou -c $im_w -r $im_h -o $out8
+cat ./output/out*.txt>./output/${exp}_iou${iou}_split.txt
+
+if ! [ -z "$2" ]
+  then
+    mkdir -p ../../${2}/${1}
+    cp ./output/${exp}_iou${iou}_split.txt ../../${2}/${1}/test_result.txt
+fi

--- a/tools/culane_evaluation_py/eval_validation.sh
+++ b/tools/culane_evaluation_py/eval_validation.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+root=../../
+data_dir=../../../../dataset/culane/
+exp=$1
+detect_dir=../../output/
+
+# These can not be changed
+w_lane=30;
+iou=0.5;  # Set iou to 0.3 or 0.5
+im_w=1640
+im_h=590
+list=${data_dir}list/val.txt
+out=./output/${exp}_iou${iou}_validation.txt
+python evaluate.py -a $data_dir -d $detect_dir -l $list -w $w_lane -t $iou -c $im_w -r $im_h -o $out
+
+if ! [ -z "$2" ]
+  then
+    mkdir -p ../../${2}/${1}
+    cp ${out} ../../${2}/${1}/val_result.txt
+fi

--- a/tools/culane_evaluation_py/evaluate.py
+++ b/tools/culane_evaluation_py/evaluate.py
@@ -1,0 +1,88 @@
+# modified from Turoad/lanedet to align with original Cpp scripts
+import os
+import argparse
+from functools import partial
+from p_tqdm import p_map
+
+from culane_metric import culane_metric
+
+
+def load_culane_data_one(path):
+    with open(path, 'r') as data_file:
+        t = data_file.readlines()
+    t = [line.split() for line in t]
+    t = [list(map(float, lane)) for lane in t]
+    t = [[(lane[i], lane[i + 1]) for i in range(0, len(lane), 2)] for lane in t]
+    t = [lane for lane in t if len(lane) >= 2]
+
+    return t
+
+
+def load_culane_data(data_dir, file_list_path):
+    with open(file_list_path, 'r') as file_list:
+        filepaths = [
+            os.path.join(data_dir, line[1 if line[0] == '/' else 0:].rstrip().replace('.jpg', '.lines.txt'))
+            for line in file_list.readlines()
+        ]
+
+    data = []
+    for path in filepaths:
+        img_data = load_culane_data_one(path)
+        data.append(img_data)
+
+    return data
+
+
+def eval_predictions(args, official=True):
+    print('List file: {}'.format(args.list_path))
+    print('Width lane: {}'.format(args.width))
+    print('IoU threshold: {}'.format(args.threshold))
+    print('Image height: {}'.format(args.img_height))
+    print('Image width: {}'.format(args.img_width))
+    print('Loading prediction data...')
+    predictions = load_culane_data(args.pred_dir, args.list_path)
+    print('Loading annotation data...')
+    annotations = load_culane_data(args.anno_dir, args.list_path)
+    print('Calculating metric in parallel...')
+    img_shape = (args.img_height, args.img_width, 3)
+    results = p_map(partial(culane_metric, width=args.width, iou_threshold=args.threshold, official=official, img_shape=img_shape),
+                    predictions, annotations)
+    total_tp = sum(tp for tp, _, _, _, _ in results)
+    total_fp = sum(fp for _, fp, _, _, _ in results)
+    total_fn = sum(fn for _, _, fn, _, _ in results)
+    if total_tp == 0:
+        precision = 0.0
+        recall = 0.0
+        f1 = 0.0
+    else:
+        precision = float(total_tp) / (total_tp + total_fp)
+        recall = float(total_tp) / (total_tp + total_fn)
+        f1 = 2 * precision * recall / (precision + recall)
+
+    return {'TP': total_tp, 'FP': total_fp, 'FN': total_fn, 'Precision': precision, 'Recall': recall, 'F1': f1}
+
+
+if __name__ == '__main__':
+    # Settings
+    # retain original defaults
+    # remove unused/not needed: -i -f -s
+    parser = argparse.ArgumentParser(description='CULane test')
+    parser.add_argument('-a', '--anno-dir', type=str, help='directory for annotation files', default='/data/driving/eval_data/anno_label/')
+    parser.add_argument('-d', '--pred-dir', type=str, help='directory for detection files', default='/data/driving/eval_data/predict_label/')
+    parser.add_argument('-l', '--list-path', type=str, help='directory for image files', default='/data/driving/eval_data/img/')
+    parser.add_argument('-w', '--width', type=int, help='width of the lanes', default=10)
+    parser.add_argument('-t', '--threshold', type=float, help='threshold of iou', default=0.4)
+    parser.add_argument('-c', '--img-width', type=int, help='cols (max image width)', default=1920)
+    parser.add_argument('-r', '--img-height', type=int, help='rows (max image height)', default=1080)
+    parser.add_argument('-o', '--output-path', type=str, help='result txt output path', default='./output.txt')
+
+    _args = parser.parse_args()
+    res = eval_predictions(_args)
+    for k, v in res.items():
+        print('{}: {:.6f}'.format(k, v) if type(v) == float else '{}: {}'.format(k, v))
+    with open(_args.output_path, 'w') as f:
+        f.write('file: {}\n'.format(_args.output_path))
+        f.write('tp: {} fp: {} fn: {}\n'.format(res['TP'], res['FP'], res['FN']))
+        f.write('precision: {:.6f}\n'.format(res['Precision']))
+        f.write('recall: {:.6f}\n'.format(res['Recall']))
+        f.write('Fmeasure: {:.6f}\n\n'.format(res['F1']))


### PR DESCRIPTION
Currently, we can observe a small diff between python & cpp backends (~0.1% in terms of #TP).

Use the python backend by modifying `autotest_culane.sh` - `$backend`
