### PR TITLE
Support PyTorch 1.7+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ scipy==1.5.4
 scikit_learn==0.23.2
 filetype==1.0.8
 importmagician>=0.1.0
-timm==0.3.2
+timm==0.4.5
 ninja>=1.8.2


### PR DESCRIPTION
After the SCNN & RESA support of PyTorch >= 1.8 in #139. 

This PR bump timm version from 0.3.2 to 0.4.5 to fully support PyTorch 1.7+. Previously, there is an error like this:

`cannot import name 'container_abcs' from 'torch._six'`

reference: https://github.com/huggingface/pytorch-image-models/pull/421